### PR TITLE
chore(build): migrate github actions to org-wide actions [skip ci]

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -1,33 +1,10 @@
-# https://github.com/gradle/actions/blob/main/docs/dependency-submission.md
-# https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#github-dependency-graph-support
-# https://github.com/gradle/github-dependency-graph-gradle-plugin
-
 name: Gradle Dependency Submission
 
 on:
   push:
-    branches: [ "main", "master" ]
-
-permissions:
-  contents: write
+    branches: [main, master]
 
 jobs:
   dependency-submission:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: corretto
-          java-version: 21
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          dependency-graph: generate-and-submit
-          build-scan-publish: false
-          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
-          build-scan-terms-of-use-agree: "yes"
-      - name: Resolve dependencies for dependency graph
-        run: ./gradlew :ForceDependencyResolutionPlugin_resolveAllDependencies
+    uses: Widen/github-actions/.github/workflows/gradle-dependency-submission-workflow.yml@v1
+    secrets: inherit


### PR DESCRIPTION
### Description
Replaces locally-maintained GitHub Actions workflow files with thin callers
that delegate to the org-wide reusable workflows in [Widen/github-actions](https://github.com/Widen/github-actions).

Mirrors [Widen/mica-skeleton#366](https://github.com/Widen/mica-skeleton/pull/366).

Brought to you by Widen/hydropull, `mise run prs:open-hoist-github-actions`.

Note: `[skip ci]` intentionally suppresses Buildkite and most GitHub Actions for this bulk infra PR. `pr-labeler` still fires via `pull_request_target`.
